### PR TITLE
Autofix

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -47,13 +47,13 @@ pub fn available_check_names() -> Vec<String> {
     names
 }
 
-pub fn run(lines: Vec<LineEntry>, skip_checks: &[&str]) -> Vec<Warning> {
+pub fn run(lines: &[LineEntry], skip_checks: &[&str]) -> Vec<Warning> {
     let mut checks = checklist();
     checks.retain(|c| !skip_checks.contains(&c.name()));
 
     let mut warnings: Vec<Warning> = Vec::new();
 
-    for line in &lines {
+    for line in lines {
         let is_comment = line.is_comment();
         for ch in &mut checks {
             if is_comment && ch.skip_comments() {
@@ -103,7 +103,7 @@ mod tests {
         let expected: Vec<Warning> = Vec::new();
         let skip_checks: Vec<&str> = Vec::new();
 
-        assert_eq!(expected, run(empty, &skip_checks));
+        assert_eq!(expected, run(&empty, &skip_checks));
     }
 
     #[test]
@@ -112,7 +112,7 @@ mod tests {
         let expected: Vec<Warning> = Vec::new();
         let skip_checks: Vec<&str> = Vec::new();
 
-        assert_eq!(expected, run(lines, &skip_checks));
+        assert_eq!(expected, run(&lines, &skip_checks));
     }
 
     #[test]
@@ -124,7 +124,7 @@ mod tests {
         let expected: Vec<Warning> = Vec::new();
         let skip_checks: Vec<&str> = Vec::new();
 
-        assert_eq!(expected, run(lines, &skip_checks));
+        assert_eq!(expected, run(&lines, &skip_checks));
     }
 
     #[test]
@@ -133,7 +133,7 @@ mod tests {
         let expected: Vec<Warning> = Vec::new();
         let skip_checks: Vec<&str> = Vec::new();
 
-        assert_eq!(expected, run(lines, &skip_checks));
+        assert_eq!(expected, run(&lines, &skip_checks));
     }
 
     #[test]
@@ -141,15 +141,14 @@ mod tests {
         let line = line_entry(1, 2, "FOO");
         let warning = Warning::new(
             line.clone(),
-            String::from(
-                "KeyWithoutValue: The FOO key should be with a value or have an equal sign",
-            ),
+            "KeyWithoutValue",
+            String::from("The FOO key should be with a value or have an equal sign"),
         );
         let lines: Vec<LineEntry> = vec![line, blank_line_entry(2, 2)];
         let expected: Vec<Warning> = vec![warning];
         let skip_checks: Vec<&str> = Vec::new();
 
-        assert_eq!(expected, run(lines, &skip_checks));
+        assert_eq!(expected, run(&lines, &skip_checks));
     }
 
     #[test]
@@ -157,13 +156,14 @@ mod tests {
         let line = line_entry(1, 1, "FOO=BAR");
         let warning = Warning::new(
             line.clone(),
-            String::from("EndingBlankLine: No blank line at the end of the file"),
+            "EndingBlankLine",
+            String::from("No blank line at the end of the file"),
         );
         let lines: Vec<LineEntry> = vec![line];
         let expected: Vec<Warning> = vec![warning];
         let skip_checks: Vec<&str> = Vec::new();
 
-        assert_eq!(expected, run(lines, &skip_checks));
+        assert_eq!(expected, run(&lines, &skip_checks));
     }
 
     #[test]
@@ -172,13 +172,14 @@ mod tests {
         let line2 = line_entry(2, 3, "1FOO\n");
         let warning = Warning::new(
             line2.clone(),
-            String::from("LeadingCharacter: Invalid leading character detected"),
+            "LeadingCharacter",
+            String::from("Invalid leading character detected"),
         );
         let lines: Vec<LineEntry> = vec![line1, line2, blank_line_entry(3, 3)];
         let expected: Vec<Warning> = vec![warning];
         let skip_checks: Vec<&str> = vec!["KeyWithoutValue"];
 
-        assert_eq!(expected, run(lines, &skip_checks));
+        assert_eq!(expected, run(&lines, &skip_checks));
     }
 
     #[test]
@@ -188,7 +189,7 @@ mod tests {
         let expected: Vec<Warning> = Vec::new();
         let skip_checks: Vec<&str> = vec!["KeyWithoutValue", "EndingBlankLine"];
 
-        assert_eq!(expected, run(lines, &skip_checks));
+        assert_eq!(expected, run(&lines, &skip_checks));
     }
 
     #[test]

--- a/src/checks/duplicated_key.rs
+++ b/src/checks/duplicated_key.rs
@@ -10,7 +10,7 @@ pub(crate) struct DuplicatedKeyChecker<'a> {
 
 impl DuplicatedKeyChecker<'_> {
     fn message(&self, key: &str) -> String {
-        format!("{}: {}", self.name, self.template.replace("{}", &key))
+        self.template.replace("{}", &key)
     }
 }
 
@@ -29,7 +29,7 @@ impl Check for DuplicatedKeyChecker<'_> {
         let key = line.get_key()?;
 
         if self.keys.contains(&key) {
-            return Some(Warning::new(line.clone(), self.message(&key)));
+            return Some(Warning::new(line.clone(), self.name(), self.message(&key)));
         }
 
         self.keys.insert(key);
@@ -90,7 +90,8 @@ mod tests {
                         },
                         raw_string: String::from("FOO=BAR"),
                     },
-                    String::from("DuplicatedKey: The FOO key is duplicated"),
+                    "DuplicatedKey",
+                    String::from("The FOO key is duplicated"),
                 )),
             ),
         ];
@@ -165,7 +166,8 @@ mod tests {
                         },
                         raw_string: String::from("FOO=BAR"),
                     },
-                    String::from("DuplicatedKey: The FOO key is duplicated"),
+                    "DuplicatedKey",
+                    String::from("The FOO key is duplicated"),
                 )),
             ),
             (
@@ -200,7 +202,8 @@ mod tests {
                         },
                         raw_string: String::from("BAR=FOO"),
                     },
-                    String::from("DuplicatedKey: The BAR key is duplicated"),
+                    "DuplicatedKey",
+                    String::from("The BAR key is duplicated"),
                 )),
             ),
         ];
@@ -243,7 +246,8 @@ mod tests {
                         },
                         raw_string: String::from("FOO=BAR"),
                     },
-                    String::from("DuplicatedKey: The FOO key is duplicated"),
+                    "DuplicatedKey",
+                    String::from("The FOO key is duplicated"),
                 )),
             ),
             (

--- a/src/checks/ending_blank_line.rs
+++ b/src/checks/ending_blank_line.rs
@@ -17,14 +17,14 @@ impl Default for EndingBlankLineChecker<'_> {
 
 impl EndingBlankLineChecker<'_> {
     fn message(&self) -> String {
-        format!("{}: {}", self.name, self.template)
+        String::from(self.template)
     }
 }
 
 impl Check for EndingBlankLineChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         if line.is_last_line() && !line.raw_string.ends_with(LF) {
-            Some(Warning::new(line.clone(), self.message()))
+            Some(Warning::new(line.clone(), self.name(), self.message()))
         } else {
             None
         }
@@ -91,7 +91,8 @@ mod tests {
         };
         let expected = Some(Warning::new(
             line.clone(),
-            String::from("EndingBlankLine: No blank line at the end of the file"),
+            "EndingBlankLine",
+            String::from("No blank line at the end of the file"),
         ));
 
         assert_eq!(expected, checker.run(&line));

--- a/src/checks/extra_blank_line.rs
+++ b/src/checks/extra_blank_line.rs
@@ -9,15 +9,15 @@ pub(crate) struct ExtraBlankLineChecker<'a> {
 
 impl ExtraBlankLineChecker<'_> {
     fn message(&self) -> String {
-        return format!("{}: {}", self.name, self.template);
+        String::from(self.template)
     }
 }
 
 impl Default for ExtraBlankLineChecker<'_> {
     fn default() -> Self {
         Self {
-            name: "ExtraBlankLine",
             template: "Extra blank line detected",
+            name: "ExtraBlankLine",
             last_blank_number: None,
         }
     }
@@ -35,7 +35,7 @@ impl Check for ExtraBlankLineChecker<'_> {
         self.last_blank_number = Some(line.number);
 
         if is_extra {
-            return Some(Warning::new(line.clone(), self.message()));
+            return Some(Warning::new(line.clone(), self.name(), self.message()));
         }
 
         None
@@ -65,7 +65,8 @@ mod tests {
                 },
                 raw_string: String::from(content),
             };
-            let expected = message.map(|msg| Warning::new(line.clone(), String::from(msg)));
+            let expected =
+                message.map(|msg| Warning::new(line.clone(), "ExtraBlankLine", String::from(msg)));
 
             assert_eq!(checker.run(&line), expected);
         }
@@ -90,7 +91,7 @@ mod tests {
         let asserts = vec![
             ("A=B", None),
             ("", None),
-            ("", Some("ExtraBlankLine: Extra blank line detected")),
+            ("", Some("Extra blank line detected")),
             ("C=D", None),
         ];
 
@@ -102,8 +103,8 @@ mod tests {
         let asserts = vec![
             ("A=B", None),
             ("", None),
-            ("", Some("ExtraBlankLine: Extra blank line detected")),
-            ("", Some("ExtraBlankLine: Extra blank line detected")),
+            ("", Some("Extra blank line detected")),
+            ("", Some("Extra blank line detected")),
             ("C=D", None),
         ];
 

--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -8,7 +8,7 @@ pub(crate) struct IncorrectDelimiterChecker<'a> {
 
 impl IncorrectDelimiterChecker<'_> {
     fn message(&self, key: &str) -> String {
-        format!("{}: {}", self.name, self.template.replace("{}", &key))
+        self.template.replace("{}", &key)
     }
 }
 
@@ -25,7 +25,7 @@ impl Check for IncorrectDelimiterChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         let key = line.get_key()?;
         if key.trim().chars().any(|c| !c.is_alphanumeric() && c != '_') {
-            return Some(Warning::new(line.clone(), self.message(&key)));
+            return Some(Warning::new(line.clone(), self.name(), self.message(&key)));
         }
 
         None
@@ -85,7 +85,8 @@ mod tests {
         };
         let expected = Some(Warning::new(
             line.clone(),
-            String::from("IncorrectDelimiter: The FOO-BAR key has incorrect delimiter"),
+            "IncorrectDelimiter",
+            String::from("The FOO-BAR key has incorrect delimiter"),
         ));
         assert_eq!(expected, checker.run(&line));
     }
@@ -104,7 +105,8 @@ mod tests {
         };
         let expected = Some(Warning::new(
             line.clone(),
-            String::from("IncorrectDelimiter: The FOO BAR key has incorrect delimiter"),
+            "IncorrectDelimiter",
+            String::from("The FOO BAR key has incorrect delimiter"),
         ));
         assert_eq!(expected, checker.run(&line));
     }

--- a/src/checks/key_without_value.rs
+++ b/src/checks/key_without_value.rs
@@ -17,14 +17,18 @@ impl Default for KeyWithoutValueChecker<'_> {
 
 impl KeyWithoutValueChecker<'_> {
     fn message(&self, key: &str) -> String {
-        format!("{}: {}", self.name, self.template.replace("{}", &key))
+        self.template.replace("{}", &key)
     }
 }
 
 impl Check for KeyWithoutValueChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         if !(line.is_empty() || line.raw_string.contains('=')) {
-            Some(Warning::new(line.clone(), self.message(&line.raw_string)))
+            Some(Warning::new(
+                line.clone(),
+                self.name(),
+                self.message(&line.raw_string),
+            ))
         } else {
             None
         }
@@ -99,9 +103,8 @@ mod tests {
         };
         let expected = Some(Warning::new(
             line.clone(),
-            String::from(
-                "KeyWithoutValue: The FOO key should be with a value or have an equal sign",
-            ),
+            "KeyWithoutValue",
+            String::from("The FOO key should be with a value or have an equal sign"),
         ));
         assert_eq!(expected, checker.run(&line));
     }

--- a/src/checks/leading_character.rs
+++ b/src/checks/leading_character.rs
@@ -17,7 +17,7 @@ impl Default for LeadingCharacterChecker<'_> {
 
 impl LeadingCharacterChecker<'_> {
     fn message(&self) -> String {
-        format!("{}: {}", self.name, self.template)
+        String::from(self.template)
     }
 }
 
@@ -30,7 +30,7 @@ impl Check for LeadingCharacterChecker<'_> {
         {
             None
         } else {
-            Some(Warning::new(line.clone(), self.message()))
+            Some(Warning::new(line.clone(), self.name(), self.message()))
         }
     }
 
@@ -44,7 +44,7 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    const MESSAGE: &str = "LeadingCharacter: Invalid leading character detected";
+    const MESSAGE: &str = "Invalid leading character detected";
 
     #[test]
     fn normal() {
@@ -104,7 +104,11 @@ mod tests {
             raw_string: String::from(".FOO=BAR"),
         };
         assert_eq!(
-            Some(Warning::new(line.clone(), MESSAGE.to_string())),
+            Some(Warning::new(
+                line.clone(),
+                "LeadingCharacter",
+                MESSAGE.to_string()
+            )),
             checker.run(&line)
         );
     }
@@ -122,7 +126,11 @@ mod tests {
             raw_string: String::from("*FOO=BAR"),
         };
         assert_eq!(
-            Some(Warning::new(line.clone(), MESSAGE.to_string())),
+            Some(Warning::new(
+                line.clone(),
+                "LeadingCharacter",
+                MESSAGE.to_string()
+            )),
             checker.run(&line)
         );
     }
@@ -140,7 +148,11 @@ mod tests {
             raw_string: String::from("1FOO=BAR"),
         };
         assert_eq!(
-            Some(Warning::new(line.clone(), MESSAGE.to_string())),
+            Some(Warning::new(
+                line.clone(),
+                "LeadingCharacter",
+                MESSAGE.to_string()
+            )),
             checker.run(&line)
         );
     }
@@ -157,7 +169,11 @@ mod tests {
             },
             raw_string: String::from(" FOO=BAR"),
         };
-        let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
+        let expected = Some(Warning::new(
+            line.clone(),
+            "LeadingCharacter",
+            MESSAGE.to_string(),
+        ));
         assert_eq!(expected, checker.run(&line));
     }
 
@@ -173,7 +189,11 @@ mod tests {
             },
             raw_string: String::from("  FOO=BAR"),
         };
-        let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
+        let expected = Some(Warning::new(
+            line.clone(),
+            "LeadingCharacter",
+            MESSAGE.to_string(),
+        ));
         assert_eq!(expected, checker.run(&line));
     }
 
@@ -189,7 +209,11 @@ mod tests {
             },
             raw_string: String::from("\tFOO=BAR"),
         };
-        let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
+        let expected = Some(Warning::new(
+            line.clone(),
+            "LeadingCharacter",
+            MESSAGE.to_string(),
+        ));
         assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/lowercase_key.rs
+++ b/src/checks/lowercase_key.rs
@@ -21,7 +21,7 @@ impl Check for LowercaseKeyChecker<'_> {
         if key.to_uppercase() == key {
             None
         } else {
-            Some(Warning::new(line.clone(), self.message(&key)))
+            Some(Warning::new(line.clone(), self.name(), self.message(&key)))
         }
     }
 
@@ -32,7 +32,7 @@ impl Check for LowercaseKeyChecker<'_> {
 
 impl LowercaseKeyChecker<'_> {
     fn message(&self, key: &str) -> String {
-        format!("{}: {}", self.name, self.template.replace("{}", key))
+        self.template.replace("{}", key)
     }
 }
 
@@ -70,7 +70,8 @@ mod tests {
         };
         let expected = Some(Warning::new(
             line.clone(),
-            String::from("LowercaseKey: The foo_bar key should be in uppercase"),
+            "LowercaseKey",
+            String::from("The foo_bar key should be in uppercase"),
         ));
         assert_eq!(expected, checker.run(&line));
     }
@@ -89,7 +90,8 @@ mod tests {
         };
         let expected = Some(Warning::new(
             line.clone(),
-            String::from("LowercaseKey: The FOo_BAR key should be in uppercase"),
+            "LowercaseKey",
+            String::from("The FOo_BAR key should be in uppercase"),
         ));
         assert_eq!(expected, checker.run(&line));
     }

--- a/src/checks/quote_character.rs
+++ b/src/checks/quote_character.rs
@@ -8,7 +8,7 @@ pub(crate) struct QuoteCharacterChecker<'a> {
 
 impl QuoteCharacterChecker<'_> {
     fn message(&self) -> String {
-        format!("{}: {}", self.name, self.template)
+        String::from(self.template)
     }
 }
 
@@ -25,7 +25,7 @@ impl Check for QuoteCharacterChecker<'_> {
     fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         let val = line.get_value()?;
         if val.contains('\"') || val.contains('\'') {
-            Some(Warning::new(line.clone(), self.message()))
+            Some(Warning::new(line.clone(), self.name(), self.message()))
         } else {
             None
         }
@@ -85,7 +85,8 @@ mod tests {
                         },
                         raw_string: String::from("FOO='BAR'"),
                     },
-                    String::from("QuoteCharacter: The value is wrapped in quotes"),
+                    "QuoteCharacter",
+                    String::from("The value is wrapped in quotes"),
                 )),
             ),
         ];
@@ -128,7 +129,8 @@ mod tests {
                         },
                         raw_string: String::from("FOO=\"BAR\""),
                     },
-                    String::from("QuoteCharacter: The value is wrapped in quotes"),
+                    "QuoteCharacter",
+                    String::from("The value is wrapped in quotes"),
                 )),
             ),
         ];

--- a/src/checks/space_character.rs
+++ b/src/checks/space_character.rs
@@ -8,7 +8,7 @@ pub(crate) struct SpaceCharacterChecker<'a> {
 
 impl SpaceCharacterChecker<'_> {
     fn message(&self) -> String {
-        format!("{}: {}", self.name, self.template)
+        String::from(self.template)
     }
 }
 
@@ -27,7 +27,7 @@ impl Check for SpaceCharacterChecker<'_> {
 
         if let [key, value] = &line_splitted[..] {
             if key.ends_with(' ') || value.starts_with(' ') {
-                return Some(Warning::new(line.clone(), self.message()));
+                return Some(Warning::new(line.clone(), self.name(), self.message()));
             }
         }
 
@@ -44,7 +44,7 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    const MESSAGE: &str = "SpaceCharacter: The line has spaces around equal sign";
+    const MESSAGE: &str = "The line has spaces around equal sign";
 
     #[test]
     fn working_run() {
@@ -133,7 +133,11 @@ mod tests {
             },
             raw_string: String::from("DEBUG-HTTP = true"),
         };
-        let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
+        let expected = Some(Warning::new(
+            line.clone(),
+            "SpaceCharacter",
+            MESSAGE.to_string(),
+        ));
         assert_eq!(expected, checker.run(&line));
     }
 
@@ -149,7 +153,11 @@ mod tests {
             },
             raw_string: String::from("DEBUG-HTTP =true"),
         };
-        let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
+        let expected = Some(Warning::new(
+            line.clone(),
+            "SpaceCharacter",
+            MESSAGE.to_string(),
+        ));
         assert_eq!(expected, checker.run(&line));
     }
 
@@ -165,7 +173,11 @@ mod tests {
             },
             raw_string: String::from("DEBUG-HTTP= true"),
         };
-        let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
+        let expected = Some(Warning::new(
+            line.clone(),
+            "SpaceCharacter",
+            MESSAGE.to_string(),
+        ));
         assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/trailing_whitespace.rs
+++ b/src/checks/trailing_whitespace.rs
@@ -8,7 +8,7 @@ pub(crate) struct TrailingWhitespaceChecker<'a> {
 
 impl TrailingWhitespaceChecker<'_> {
     fn message(&self) -> String {
-        return format!("{}: {}", self.name, self.template);
+        String::from(self.template)
     }
 }
 
@@ -26,7 +26,7 @@ impl Check for TrailingWhitespaceChecker<'_> {
         let raw_string = &line.raw_string;
 
         if raw_string.ends_with(' ') {
-            return Some(Warning::new(line.clone(), self.message()));
+            return Some(Warning::new(line.clone(), self.name, self.message()));
         }
 
         None
@@ -42,7 +42,7 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    const MESSAGE: &str = "TrailingWhitespace: Trailing whitespace detected";
+    const MESSAGE: &str = "Trailing whitespace detected";
 
     #[test]
     fn working_run() {
@@ -73,7 +73,11 @@ mod tests {
             raw_string: String::from("DEBUG_HTTP=true  "),
         };
 
-        let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
+        let expected = Some(Warning::new(
+            line.clone(),
+            "TrailingWhitespace",
+            MESSAGE.to_string(),
+        ));
         assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/unordered_key.rs
+++ b/src/checks/unordered_key.rs
@@ -9,21 +9,17 @@ pub(crate) struct UnorderedKeyChecker<'a> {
 
 impl UnorderedKeyChecker<'_> {
     fn message(&self, key_one: &str, key_two: &str) -> String {
-        return format!(
-            "{}: {}",
-            self.name,
-            self.template
-                .replace("{1}", key_one)
-                .replace("{2}", key_two)
-        );
+        self.template
+            .replace("{1}", key_one)
+            .replace("{2}", key_two)
     }
 }
 
 impl Default for UnorderedKeyChecker<'_> {
     fn default() -> Self {
         Self {
-            keys: Vec::new(),
             name: "UnorderedKey",
+            keys: Vec::new(),
             template: "The {1} key should go before the {2} key",
         }
     }
@@ -46,7 +42,7 @@ impl Check for UnorderedKeyChecker<'_> {
 
             let another_key = sorted_keys.get(index + 1)?;
 
-            let warning = Warning::new(line.clone(), self.message(&key, &another_key));
+            let warning = Warning::new(line.clone(), self.name(), self.message(&key, &another_key));
             return Some(warning);
         }
 
@@ -157,7 +153,8 @@ mod tests {
                         },
                         raw_string: String::from("BAR=FOO"),
                     },
-                    String::from("UnorderedKey: The BAR key should go before the FOO key"),
+                    "UnorderedKey",
+                    String::from("The BAR key should go before the FOO key"),
                 )),
             ),
         ];
@@ -200,7 +197,8 @@ mod tests {
                         },
                         raw_string: String::from("BAR=FOO"),
                     },
-                    String::from("UnorderedKey: The BAR key should go before the FOO key"),
+                    "UnorderedKey",
+                    String::from("The BAR key should go before the FOO key"),
                 )),
             ),
             (
@@ -223,7 +221,8 @@ mod tests {
                         },
                         raw_string: String::from("ABC=BAR"),
                     },
-                    String::from("UnorderedKey: The ABC key should go before the BAR key"),
+                    "UnorderedKey",
+                    String::from("The ABC key should go before the BAR key"),
                 )),
             ),
         ];
@@ -266,7 +265,8 @@ mod tests {
                         },
                         raw_string: String::from("BAR=FOO"),
                     },
-                    String::from("UnorderedKey: The BAR key should go before the FOO key"),
+                    "UnorderedKey",
+                    String::from("The BAR key should go before the FOO key"),
                 )),
             ),
             (
@@ -289,7 +289,8 @@ mod tests {
                         },
                         raw_string: String::from("DDD=BAR"),
                     },
-                    String::from("UnorderedKey: The DDD key should go before the FOO key"),
+                    "UnorderedKey",
+                    String::from("The DDD key should go before the FOO key"),
                 )),
             ),
         ];
@@ -332,7 +333,8 @@ mod tests {
                         },
                         raw_string: String::from("BAR=FOO"),
                     },
-                    String::from("UnorderedKey: The BAR key should go before the FOO key"),
+                    "UnorderedKey",
+                    String::from("The BAR key should go before the FOO key"),
                 )),
             ),
             (
@@ -355,7 +357,8 @@ mod tests {
                         },
                         raw_string: String::from("DDD=BAR"),
                     },
-                    String::from("UnorderedKey: The DDD key should go before the FOO key"),
+                    "UnorderedKey",
+                    String::from("The DDD key should go before the FOO key"),
                 )),
             ),
             (

--- a/src/common.rs
+++ b/src/common.rs
@@ -5,22 +5,57 @@ use std::path::PathBuf;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Warning {
+    pub check_name: String,
     line: LineEntry,
     message: String,
+    pub is_fixed: Option<bool>,
 }
 
 impl Warning {
-    pub fn new(line: LineEntry, message: String) -> Self {
-        Self { line, message }
+    pub fn new(line: LineEntry, check_name: &str, message: String) -> Self {
+        let check_name = String::from(check_name);
+        Self {
+            line,
+            check_name,
+            message,
+            is_fixed: None,
+        }
+    }
+
+    pub fn line_number(&self) -> usize {
+        self.line.number
+    }
+
+    pub fn file(&self) -> &FileEntry {
+        &self.line.file
+    }
+
+    pub fn set_fixed(&mut self, val: bool) {
+        self.is_fixed = Some(val);
     }
 }
 
 impl fmt::Display for Warning {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let fixed_prefix = match self.is_fixed {
+            Some(is_fixed) => {
+                if is_fixed {
+                    "  Fixed: "
+                } else {
+                    "Unfixed: "
+                }
+            }
+            None => "",
+        };
+
         write!(
             f,
-            "{}:{} {}",
-            self.line.file, self.line.number, self.message
+            "{}{}:{} {}: {}",
+            fixed_prefix,
+            self.file(),
+            self.line_number(),
+            self.check_name,
+            self.message
         )
     }
 }
@@ -167,7 +202,8 @@ mod tests {
         };
         let warning = Warning::new(
             line,
-            String::from("DuplicatedKey: The FOO key is duplicated"),
+            "DuplicatedKey",
+            String::from("The FOO key is duplicated"),
         );
 
         assert_eq!(

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -1,0 +1,16 @@
+use std::fs::File;
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+use crate::common::LineEntry;
+
+// I think that we should create a backup copy
+pub fn write(path: &PathBuf, lines: Vec<LineEntry>) -> io::Result<()> {
+    let mut file = File::create(path)?;
+
+    for line in lines[..lines.len() - 1].iter() {
+        writeln!(file, "{}", line.raw_string)?;
+    }
+
+    Ok(())
+}

--- a/src/fixes.rs
+++ b/src/fixes.rs
@@ -1,0 +1,80 @@
+use crate::common::*;
+
+mod ending_blank_line;
+mod extra_blank_line;
+mod lowercase_key;
+mod unordered_key;
+
+trait Fix {
+    fn name(&self) -> &str;
+
+    fn fix_warnings(
+        &self,
+        warnings: Vec<&mut Warning>,
+        lines: &mut Vec<LineEntry>,
+    ) -> Option<usize> {
+        let mut count: usize = 0;
+        for warning in warnings {
+            let line = &mut lines[warning.line_number() - 1];
+            if self.fix_line(line).is_some() {
+                warning.set_fixed(true);
+                count += 1;
+            }
+        }
+
+        Some(count)
+    }
+
+    fn fix_line(&self, _line: &mut LineEntry) -> Option<()> {
+        None
+    }
+
+    fn set_fixed_on_all(&self, warnings: Vec<&mut Warning>) -> Option<usize> {
+        let count = warnings.len();
+        for warning in warnings {
+            warning.set_fixed(true);
+        }
+
+        Some(count)
+    }
+}
+
+// TODO: skip fixes (like checks)
+// The fix order is matter
+fn fixlist() -> Vec<Box<dyn Fix>> {
+    vec![
+        // At first we run the fixers that handle a single line entry (they use default
+        // implementation of the fix_warnings() function)
+        Box::new(lowercase_key::LowercaseKeyFixer::default()),
+        // Then we run the fixers that handle the line entry collection at whole
+        Box::new(ending_blank_line::EndingBlankLineFixer::default()),
+        Box::new(unordered_key::UnorderedKeyFixer::default()),
+        // At the end we run ExtraBlankLineFixer (because the previous fixers can create
+        // additional extra blank lines)
+        Box::new(extra_blank_line::ExtraBlankLineFixer::default()),
+    ]
+}
+
+pub fn run(warnings: &mut [Warning], lines: &mut Vec<LineEntry>) -> usize {
+    if warnings.is_empty() {
+        return 0;
+    }
+
+    for warning in warnings.iter_mut() {
+        warning.set_fixed(false);
+    }
+
+    let mut count = 0;
+    for fixer in fixlist() {
+        // We can optimize it: create check_name:warnings map in advance
+        let fixer_warnings: Vec<&mut Warning> = warnings
+            .iter_mut()
+            .filter(|w| w.check_name == fixer.name())
+            .collect();
+        if !fixer_warnings.is_empty() || fixer.name() == "ExtraBlankLine" {
+            count += fixer.fix_warnings(fixer_warnings, lines).unwrap_or(0);
+        }
+    }
+
+    count
+}

--- a/src/fixes/ending_blank_line.rs
+++ b/src/fixes/ending_blank_line.rs
@@ -1,0 +1,41 @@
+use super::Fix;
+use crate::common::*;
+
+pub(crate) struct EndingBlankLineFixer<'a> {
+    name: &'a str,
+}
+
+impl Default for EndingBlankLineFixer<'_> {
+    fn default() -> Self {
+        Self {
+            name: "EndingBlankLine",
+        }
+    }
+}
+
+impl Fix for EndingBlankLineFixer<'_> {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn fix_warnings(
+        &self,
+        warnings: Vec<&mut Warning>,
+        lines: &mut Vec<LineEntry>,
+    ) -> Option<usize> {
+        if warnings.len() != 1 {
+            return None;
+        }
+
+        for warning in warnings {
+            lines.push(LineEntry {
+                number: warning.line_number() + 1,
+                file: warning.file().clone(),
+                raw_string: String::new(),
+            });
+            warning.set_fixed(true);
+        }
+
+        Some(1)
+    }
+}

--- a/src/fixes/extra_blank_line.rs
+++ b/src/fixes/extra_blank_line.rs
@@ -1,0 +1,30 @@
+use super::Fix;
+use crate::common::*;
+
+pub(crate) struct ExtraBlankLineFixer<'a> {
+    name: &'a str,
+}
+
+impl Default for ExtraBlankLineFixer<'_> {
+    fn default() -> Self {
+        Self {
+            name: "ExtraBlankLine",
+        }
+    }
+}
+
+impl Fix for ExtraBlankLineFixer<'_> {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn fix_warnings(
+        &self,
+        warnings: Vec<&mut Warning>,
+        lines: &mut Vec<LineEntry>,
+    ) -> Option<usize> {
+        lines.dedup_by(|a, b| a.is_empty() && b.is_empty());
+
+        self.set_fixed_on_all(warnings)
+    }
+}

--- a/src/fixes/lowercase_key.rs
+++ b/src/fixes/lowercase_key.rs
@@ -1,0 +1,28 @@
+use super::Fix;
+use crate::common::*;
+
+pub(crate) struct LowercaseKeyFixer<'a> {
+    name: &'a str,
+}
+
+impl Default for LowercaseKeyFixer<'_> {
+    fn default() -> Self {
+        Self {
+            name: "LowercaseKey",
+        }
+    }
+}
+
+impl Fix for LowercaseKeyFixer<'_> {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn fix_line(&self, line: &mut LineEntry) -> Option<()> {
+        let key = line.get_key()?;
+        let key = key.to_uppercase();
+        line.raw_string = format!("{}={}", key, line.get_value()?);
+
+        Some(())
+    }
+}

--- a/src/fixes/unordered_key.rs
+++ b/src/fixes/unordered_key.rs
@@ -1,0 +1,125 @@
+use super::Fix;
+use crate::common::*;
+
+//use std::collections::HashMap;
+
+pub(crate) struct UnorderedKeyFixer<'a> {
+    name: &'a str,
+}
+
+impl Default for UnorderedKeyFixer<'_> {
+    fn default() -> Self {
+        Self {
+            name: "UnorderedKey",
+        }
+    }
+}
+
+// When we sort the keys, we handle a significant line (with key) with all previous blank lines and
+// comments as a whole.
+// E. g.
+// ```
+// B=C
+//
+// # Comment
+// A=B
+// ```
+// will be fixed to:
+// ```
+//
+// # Comment
+// A=B
+// B=C
+// ```
+impl Fix for UnorderedKeyFixer<'_> {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn fix_warnings(
+        &self,
+        warnings: Vec<&mut Warning>,
+        lines: &mut Vec<LineEntry>,
+    ) -> Option<usize> {
+        let sorted_len = Self::get_sorted_len(lines)?;
+
+        let mut start_index = 0;
+        let mut slices = Vec::with_capacity(sorted_len);
+        for (i, line) in lines[..sorted_len].iter().enumerate() {
+            if !line.is_empty_or_comment() {
+                slices.push(&lines[start_index..=i]);
+                start_index = i + 1;
+            }
+        }
+
+        slices.sort_by_cached_key(|slice| {
+            // I think, that we should modify get_key() so it will return Option<&str> instead of
+            // Option<String>.
+            slice.last().unwrap().get_key()
+        });
+
+        let mut sorted_lines = Vec::with_capacity(lines.len());
+        for slice in slices {
+            sorted_lines.extend_from_slice(slice);
+        }
+        if sorted_len < lines.len() {
+            sorted_lines.extend_from_slice(&lines[sorted_len..lines.len()]);
+        }
+
+        lines.clear();
+        lines.append(&mut sorted_lines);
+
+        self.set_fixed_on_all(warnings)
+    }
+
+    // This is the alternative implementation. It sorts lines in place without separate
+    // Vec<LineEntry> (though allocates HashMap<usize, usize>), but it is more complicated and
+    // supposedly takes more time (because of the second sorting)
+
+    // fn fix_warnings(
+    //     &self,
+    //     warnings: Vec<&mut Warning>,
+    //     lines: &mut Vec<LineEntry>,
+    // ) -> Option<usize> {
+    //     let sorted_len = Self::get_sorted_len(lines)?;
+    //
+    //     let mut anchor_index = sorted_len - 1;
+    //     let mut sort_data: Vec<_> = lines[..sorted_len]
+    //         .iter()
+    //         .enumerate()
+    //         .rev()
+    //         .map(|(i, line)| {
+    //             if !line.is_empty_or_comment() {
+    //                 anchor_index = i;
+    //             }
+    //             (anchor_index, line.number)
+    //         })
+    //         .collect();
+    //
+    //     sort_data.sort_by_cached_key(|&(anchor_index, line_number)| {
+    //         let anchor_line = &lines[anchor_index];
+    //         (anchor_line.get_key(), line_number)
+    //     });
+    //
+    //     let mut map = HashMap::with_capacity(sorted_len);
+    //     for (i, (_, line_number)) in sort_data.iter().enumerate() {
+    //         map.insert(line_number, i);
+    //     }
+    //
+    //     lines[..sorted_len].sort_by_key(|line| map[&line.number]);
+    //
+    //     self.set_fixed_on_all(warnings)
+    // }
+}
+
+impl UnorderedKeyFixer<'_> {
+    fn get_sorted_len(lines: &[LineEntry]) -> Option<usize> {
+        for (i, line) in lines.iter().enumerate().rev() {
+            if !line.is_empty_or_comment() {
+                return Some(i + 1);
+            }
+        }
+
+        None
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,18 @@ use std::process;
 fn main() {
     match dotenv_linter::run() {
         Ok(warnings) => {
-            if warnings.is_empty() {
+            let mut all_fixed = true;
+            warnings.iter().for_each(|w| {
+                let is_fixed = w.is_fixed.unwrap_or(false);
+                if !is_fixed {
+                    all_fixed = false;
+                }
+
+                println!("{}", w);
+            });
+            if all_fixed {
                 process::exit(0);
             }
-
-            warnings.iter().for_each(|w| println!("{}", w));
         }
         Err(error) => {
             eprintln!("dotenv-linter: {}", error);

--- a/tests/autofix/mod.rs
+++ b/tests/autofix/mod.rs
@@ -1,0 +1,59 @@
+use crate::common::TestDir;
+
+fn test_autofix(given: &str, fixed: &str) {
+    let testdir = TestDir::new();
+    let testfile = testdir.create_testfile(".env", given);
+
+    testdir.test_command_fix_file(&testfile, fixed);
+}
+
+#[test]
+fn correct_file() {
+    test_autofix("ABC=DEF\nD=BAR\n\nFOO=BAR\n", "ABC=DEF\nD=BAR\n\nFOO=BAR\n");
+}
+
+#[test]
+fn extra_blank_lines() {
+    test_autofix(
+        "\n\nABC=DEF\nD=BAR\n\n\nFOO=BAR\n\n",
+        "\nABC=DEF\nD=BAR\n\nFOO=BAR\n",
+    );
+}
+
+#[test]
+fn ending_blank_line() {
+    test_autofix("ABC=DEF\nD=BAR\n\nFOO=BAR", "ABC=DEF\nD=BAR\n\nFOO=BAR\n");
+}
+
+#[test]
+fn lowercase_key() {
+    test_autofix("abc=DEF\nD=BAR\n\nfOO=BAR\n", "ABC=DEF\nD=BAR\n\nFOO=BAR\n");
+}
+
+#[test]
+fn unordered_keys() {
+    test_autofix("FOO=BAR\nD=BAR\nABC=DEF\n", "ABC=DEF\nD=BAR\nFOO=BAR\n");
+
+    test_autofix(
+        "FOO=BAR\nD=BAR\nABC=DEF\n# comment\n",
+        "ABC=DEF\nD=BAR\nFOO=BAR\n# comment\n",
+    );
+
+    test_autofix(
+        "FOO=BAR\nD=BAR\n#comment\nABC=DEF\n",
+        "#comment\nABC=DEF\nD=BAR\nFOO=BAR\n",
+    );
+
+    test_autofix(
+        "FOO=BAR\nD=BAR\n\n#comment\n\nABC=DEF\n",
+        "\n#comment\n\nABC=DEF\nD=BAR\nFOO=BAR\n",
+    );
+}
+
+#[test]
+fn different_fixes() {
+    test_autofix(
+        "#cmt\nfOO=BAR\nD=BAR\n\n\n\n\n\nABC=DEF",
+        "\nABC=DEF\nD=BAR\n#cmt\nFOO=BAR\n",
+    );
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,4 +1,5 @@
 mod args;
+mod autofix;
 mod checks;
 mod common;
 mod options;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,6 @@
 use assert_cmd::Command;
 use std::ffi::OsStr;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::Write;
 use std::path::PathBuf;
 use tempfile::{tempdir, tempdir_in, TempDir};
@@ -116,6 +116,21 @@ impl TestDir {
         self.close();
     }
 
+    /// Run the default CLI binary, with "-f" for the given test file, check it succeeds and
+    /// compare the fixed file's contents with provided.
+    /// This method removes the TestDir when command has finished.
+    pub fn test_command_fix_file(self, testfile: &TestFile, contents: &str) {
+        let mut cmd = Self::init_cmd();
+        cmd.current_dir(&self.current_dir)
+            .args(&["-f", testfile.as_str()])
+            .assert()
+            .success();
+
+        assert_eq!(testfile.contents().as_str(), contents);
+
+        self.close();
+    }
+
     fn init_cmd() -> Command {
         Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("command from binary name")
     }
@@ -148,5 +163,10 @@ impl TestFile {
             .expect("get shortname")
             .to_str()
             .expect("convert shortname to &str")
+    }
+
+    /// Get file contents
+    pub fn contents(&self) -> String {
+        String::from_utf8_lossy(&fs::read(self.as_str()).unwrap()).into_owned()
     }
 }


### PR DESCRIPTION
I have implemented automatic correction of the contents of files based on the results of the check.
When displaying, all warnings are marked as Fixed or Unfixed.
If all warnings are fixed, exit code is 0.

The following types of checks are fixable for now:
* ending_blank_line;
* extra_blank_line;
* lowercase_key;
* unordered_key (the most complicated one).

The CLI key for the autofix mode is `-f`/`--fixed`.

A few comments about the design:

I added the field with a checker name to `Warning` (it is possible to determine the checker by the text of the message, but I don't like this approach).

The separate trait `Fix` was made for fixes (I tried to keep some symmetry with `checks`), but it is possible to expand the trait `Check` itself with this functions  too.

There are two groups of fixes: some can be implemented by working only with the line that caused warning, for others you need to work with the entire line collection.

The `Fix` trait allows you to work with both groups of fixes due to default function implementations.

I also left some comments about implementation of this feature in source code.

I have added the integration test for autofix.